### PR TITLE
Update theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Clean, responsive one-page portfolio accompanied by a minimalist 
 homepage = "https://github.com/tomanistor/osprey"
 tags = ["blog", "portfolio", "gallery", "minimalist", "responsive", "flexbox"]
 features = ["blog", "portfolio", "google analytics"]
-min_version = 0.24.1
+min_version = 0.24
 
 [author]
   name = "Toma Nistor"


### PR DESCRIPTION
Removed the ".1" from the end of `min_version`. Hugo gives me the following warning. Alternatively, could probably specify a newer version of Hugo to be the minimum.

`theme.toml": unmarshal failed: Near line 8 (last key parsed 'min_version'): Invalid float value: "0.24.1"`
