### PR TITLE
Update footer.html with correct LinkedIn URL

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
   {{ end }}
 
   {{ if .Site.Params.linkedin }}
-    <div class="col-xs-3 col-md-2"><a target="_blank" rel="noopener" href="https://linkedin.com/in/{{ .Site.Params.linkedin }}">{{ i18n "linkedin" }}</a></div>
+    <div class="col-xs-3 col-md-2"><a target="_blank" rel="noopener" href="https://linkedin.com/company/{{ .Site.Params.linkedin }}">{{ i18n "linkedin" }}</a></div>
   {{ end }}
 
   {{ if .Site.Params.twitter }}


### PR DESCRIPTION
For businesses, the LinkedIn URL has a different format. This works for me, but perhaps something to make configurable for your public Osprey theme and flow down to this? It's up to you.