### PR TITLE
Removed About pages from root pages nprev/next navigation

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,11 +18,16 @@
           </article>
 
           <div class="pagination">
-            {{ if .PrevInSection }}
-              <a href="{{ .PrevInSection.Permalink }}">&laquo; {{ .PrevInSection.Title }}</a>
+            {{ with .PrevInSection }}
+              {{ if (ne .Title "About") }}
+                <a href="{{ .Permalink }}">&laquo; {{ .Title }}</a>
+              {{ end }}
             {{ end }}
-            {{ if .NextInSection }}
-              <a href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }} &raquo;</a>
+            
+            {{ with .NextInSection }}
+              {{ if (ne .Title "About") }}
+                <a href="{{ .Permalink }}">{{ .Title }} &raquo;</a>
+              {{ end }}
             {{ end }}
           </div>
         </section>


### PR DESCRIPTION
To remove the "About" page link from the root pages navigation